### PR TITLE
코드리뷰 Command(생성, 수정, 삭제) 기능 구현

### DIFF
--- a/app-koi-api/src/docs/asciidoc/index.adoc
+++ b/app-koi-api/src/docs/asciidoc/index.adoc
@@ -13,37 +13,52 @@ endif::[]
 = JWT 관련 기능
 
 == 로그인
-* 로그인 부분은 추후 OAuth로 변경 예정입니다. 우선, 간단하게 만들어 놓겠습니다
+
+* 로그인 부분은 추후 OAuth로 변경 예정입니다.
+우선, 간단하게 만들어 놓겠습니다
 
 === Request
+
 include::{snippets}/auth/post-login/http-request.adoc[]
+
 === Response
+
 cookie:
+
 include::{snippets}/auth/post-login/response-cookies.adoc[]
+
 header:
+
 include::{snippets}/auth/post-login/response-headers.adoc[]
 include::{snippets}/auth/post-login/http-response.adoc[]
 
-
 == accessToken refresh
+
 === Request
+
 include::{snippets}/auth/post-login-refresh/http-request.adoc[]
+
 === Response
+
 header:
+
 include::{snippets}/auth/post-login-refresh/response-headers.adoc[]
+
 cookie:
+
 include::{snippets}/auth/post-login-refresh/response-cookies.adoc[]
 include::{snippets}/auth/post-login/http-response.adoc[]
 
-
 == 로그아웃
+
 === Request
+
 include::{snippets}/auth/post-logout/http-request.adoc[]
 
 === Response
+
 include::{snippets}/auth/post-logout/response-cookies.adoc[]
 include::{snippets}/auth/post-logout/http-response.adoc[]
-
 
 == 토큰 관련 예외 상황
 
@@ -61,8 +76,7 @@ include::{snippets}/auth/post-logout/http-response.adoc[]
 {message: "식별되지 않는 토큰입니다.", code: "AUTH_003", statusCode: 401}
 ----
 
-- [AUTH_004] RefreshToken이 유저와 매핑되지 않은 경우
-     (타인의 토큰을 이용한 경우)
+- [AUTH_004] RefreshToken이 유저와 매핑되지 않은 경우 (타인의 토큰을 이용한 경우)
 
 [source]
 ----
@@ -70,100 +84,110 @@ include::{snippets}/auth/post-logout/http-response.adoc[]
 ----
 
 - [AUTH_005] AccessToken이 만료된 경우
+
 [source]
 ----
 {message: "만료된 Access 토큰입니다. 토큰을 재활성화 해주세요.", code: "AUTH_005", statusCode: 401}
 ----
 
 - [AUTH_006] RefreshToken이 만료된 경우
+
 [source]
 ----
 {message: "만료된 Refresh 토큰입니다. 토큰을 재활성화 해주세요.", code: "AUTH_006", statusCode: 401}
 ----
 
-
 == 예외 케이스 예시
 
 * 엑세스 토큰이 반드시 필요한 경우
-    - Authroization 헤더가 없는 경우: AUTH_002
-    - Authroization 헤더가 있고 부적절한 형식: AUTH_003
-    - Authroization 헤더가 있고 시간이 만료: AUTH_005
+- Authroization 헤더가 없는 경우: AUTH_002
+- Authroization 헤더가 있고 부적절한 형식: AUTH_003
+- Authroization 헤더가 있고 시간이 만료: AUTH_005
 
 * 엑세스 토큰이 필요 없는 경우
-    - Authroization 헤더가 없는 경우: 예외 발생 X
-    - Authroization 헤더가 있고 부적절한 형식: AUTH_003
-    - Authroization 헤더가 있고 시간이 만료: AUTH_005
-    - 엑세스 토큰자체가 없으면 로그인 안한것으로 판단합니다.
-    - 다만, 부적절한 값이나 만료되었다면 특정 예외 처리가 필요합니다.
+- Authroization 헤더가 없는 경우: 예외 발생 X
+- Authroization 헤더가 있고 부적절한 형식: AUTH_003
+- Authroization 헤더가 있고 시간이 만료: AUTH_005
+- 엑세스 토큰자체가 없으면 로그인 안한것으로 판단합니다.
+- 다만, 부적절한 값이나 만료되었다면 특정 예외 처리가 필요합니다.
 
 * 엑세스 토큰이 만료되어 리프레시가 필요한 경우
-    - Authroization 헤더가 없는 경우: AUTH_002
-    - Authroization 헤더가 있고 부적절한 형식: AUTH_003
-    - Authroization 헤더가 있고 시간이 만료: 예외발생 X
-    - RefreshToken이 만료된 경우: AUTH_006
-
-
-
+- Authroization 헤더가 없는 경우: AUTH_002
+- Authroization 헤더가 있고 부적절한 형식: AUTH_003
+- Authroization 헤더가 있고 시간이 만료: 예외발생 X
+- RefreshToken이 만료된 경우: AUTH_006
 
 = 유저 [ /users ]
 
 == 유저 상세보기
+
 === Request
+
 include::{snippets}/users/get/http-request.adoc[]
 include::{snippets}/users/get/path-parameters.adoc[]
 
 === Response
+
 include::{snippets}/users/get/response-fields.adoc[]
 include::{snippets}/users/get/response-body.adoc[]
 
-
 == 유저의 코드리뷰 목록
+
 === Request
+
 include::{snippets}/users/get-userId-reviews/http-request.adoc[]
 include::{snippets}/users/get-userId-reviews/path-parameters.adoc[]
 
 === Response
+
 include::{snippets}/users/get-userId-reviews/response-fields.adoc[]
 include::{snippets}/users/get-userId-reviews/response-body.adoc[]
 
-
 == 유저가 즐겨찾기한 코드리뷰 목록
+
 === Request
+
 include::{snippets}/users/get-userId-favorite-reviews/http-request.adoc[]
 include::{snippets}/users/get-userId-favorite-reviews/path-parameters.adoc[]
 
 === Response
+
 include::{snippets}/users/get-userId-favorite-reviews/response-fields.adoc[]
 include::{snippets}/users/get-userId-favorite-reviews/response-body.adoc[]
 
-
 == 유저의 코드리뷰 댓글 목록
+
 === Request
+
 include::{snippets}/users/get-userId-comments/http-request.adoc[]
 include::{snippets}/users/get-userId-comments/path-parameters.adoc[]
 
 === Response
+
 include::{snippets}/users/get-userId-comments/response-fields.adoc[]
 include::{snippets}/users/get-userId-comments/response-body.adoc[]
 
 == 유저가 사용한 기술 스택 키워드 통계
 
 === Request
+
 include::{snippets}/users/get-userId-skills-statistics/path-parameters.adoc[]
 
 === Response
+
 include::{snippets}/users/get-userId-skills-statistics/response-fields.adoc[]
 include::{snippets}/users/get-userId-skills-statistics/response-body.adoc[]
 
 == 유저의 활동 히스토리
 
 === Request
+
 include::{snippets}/users/get-userId-logs/path-parameters.adoc[]
 
 === Response
+
 include::{snippets}/users/get-userId-logs/response-fields.adoc[]
 include::{snippets}/users/get-userId-logs/response-body.adoc[]
-
 
 = 코드리뷰 [ /code-reviews ]
 == 코드리뷰 상세 정보
@@ -172,6 +196,7 @@ include::{snippets}/codeReviews/get-reviewId/http-request.adoc[]
 include::{snippets}/codeReviews/get-reviewId/path-parameters.adoc[]
 
 === Response
+
 include::{snippets}/codeReviews/get-reviewId/response-fields.adoc[]
 include::{snippets}/codeReviews/get-reviewId/response-body.adoc[]
 
@@ -210,7 +235,7 @@ include::{snippets}/codeReviews/get-hot/http-request.adoc[]
 include::{snippets}/codeReviews/get-hot/response-fields.adoc[]
 include::{snippets}/codeReviews/get-hot/response-body.adoc[]
 
-== 코드리뷰 목록 조회
+== 코드리뷰 생성
 
 === Request
 
@@ -221,6 +246,27 @@ include::{snippets}/codeReviews/post/http-request.adoc[]
 include::{snippets}/codeReviews/post/response-fields.adoc[]
 include::{snippets}/codeReviews/post/response-body.adoc[]
 
+== 코드리뷰 수정
+
+=== Request
+
+include::{snippets}/codeReviews/put-reviewId/path-parameters.adoc[]
+include::{snippets}/codeReviews/put-reviewId/http-request.adoc[]
+
+=== Response
+
+include::{snippets}/codeReviews/put-reviewId/http-response.adoc[]
+
+== 코드리뷰 삭제
+
+=== Request
+
+include::{snippets}/codeReviews/put-reviewId/path-parameters.adoc[]
+include::{snippets}/codeReviews/put-reviewId/http-request.adoc[]
+
+=== Response
+
+include::{snippets}/codeReviews/put-reviewId/http-response.adoc[]
 
 = 좋아요 [ /likes ]
 == 좋아요하기

--- a/app-koi-api/src/docs/asciidoc/index.adoc
+++ b/app-koi-api/src/docs/asciidoc/index.adoc
@@ -210,6 +210,18 @@ include::{snippets}/codeReviews/get-hot/http-request.adoc[]
 include::{snippets}/codeReviews/get-hot/response-fields.adoc[]
 include::{snippets}/codeReviews/get-hot/response-body.adoc[]
 
+== 코드리뷰 목록 조회
+
+=== Request
+
+include::{snippets}/codeReviews/post/http-request.adoc[]
+
+=== Response
+
+include::{snippets}/codeReviews/post/response-fields.adoc[]
+include::{snippets}/codeReviews/post/response-body.adoc[]
+
+
 = 좋아요 [ /likes ]
 == 좋아요하기
 === Request

--- a/app-koi-api/src/main/java/com/codekoi/apiserver/review/controller/CodeReviewRestController.java
+++ b/app-koi-api/src/main/java/com/codekoi/apiserver/review/controller/CodeReviewRestController.java
@@ -3,6 +3,7 @@ package com.codekoi.apiserver.review.controller;
 import com.codekoi.apiserver.comment.dto.CommentReviewDetailDto;
 import com.codekoi.apiserver.comment.service.ReviewCommentQueryService;
 import com.codekoi.apiserver.review.controller.request.CreateCodeReviewRequest;
+import com.codekoi.apiserver.review.controller.request.UpdateCodeReveiwRequest;
 import com.codekoi.apiserver.review.controller.response.CodeReviewDetailResponse;
 import com.codekoi.apiserver.review.controller.response.HotCodeReviewListResponse;
 import com.codekoi.apiserver.review.controller.response.ReviewCommentListResponse;
@@ -57,5 +58,12 @@ public class CodeReviewRestController {
     public SimpleIdResponse createReview(@Principal AuthInfo authInfo, @Valid @RequestBody CreateCodeReviewRequest request) {
         final Long codeReviewId = codeReviewService.create(authInfo.getUserId(), request.title(), request.content(), request.skillIds());
         return new SimpleIdResponse(codeReviewId);
+    }
+
+    @PutMapping("/{reviewId}")
+    public void updateReview(@Principal AuthInfo authInfo,
+                             @PathVariable Long reviewId,
+                             @Valid @RequestBody UpdateCodeReveiwRequest request) {
+        codeReviewService.update(reviewId, authInfo.getUserId(), request.title(), request.content(), request.skillIds());
     }
 }

--- a/app-koi-api/src/main/java/com/codekoi/apiserver/review/controller/CodeReviewRestController.java
+++ b/app-koi-api/src/main/java/com/codekoi/apiserver/review/controller/CodeReviewRestController.java
@@ -66,4 +66,9 @@ public class CodeReviewRestController {
                              @Valid @RequestBody UpdateCodeReveiwRequest request) {
         codeReviewService.update(reviewId, authInfo.getUserId(), request.title(), request.content(), request.skillIds());
     }
+
+    @DeleteMapping("/{reviewId}")
+    public void deleteReview(@Principal AuthInfo authInfo, @PathVariable Long reviewId) {
+        codeReviewService.delete(reviewId, authInfo.getUserId());
+    }
 }

--- a/app-koi-api/src/main/java/com/codekoi/apiserver/review/controller/CodeReviewRestController.java
+++ b/app-koi-api/src/main/java/com/codekoi/apiserver/review/controller/CodeReviewRestController.java
@@ -2,6 +2,7 @@ package com.codekoi.apiserver.review.controller;
 
 import com.codekoi.apiserver.comment.dto.CommentReviewDetailDto;
 import com.codekoi.apiserver.comment.service.ReviewCommentQueryService;
+import com.codekoi.apiserver.review.controller.request.CreateCodeReviewRequest;
 import com.codekoi.apiserver.review.controller.response.CodeReviewDetailResponse;
 import com.codekoi.apiserver.review.controller.response.HotCodeReviewListResponse;
 import com.codekoi.apiserver.review.controller.response.ReviewCommentListResponse;
@@ -9,9 +10,12 @@ import com.codekoi.apiserver.review.dto.BasicCodeReview;
 import com.codekoi.apiserver.review.dto.CodeReviewDetailDto;
 import com.codekoi.apiserver.review.dto.CodeReviewListCondition;
 import com.codekoi.apiserver.review.service.CodeReviewQueryService;
+import com.codekoi.apiserver.review.service.CodeReviewService;
 import com.codekoi.coreweb.jwt.AuthInfo;
 import com.codekoi.coreweb.jwt.Principal;
 import com.codekoi.pagination.NoOffSetPagination;
+import com.codekoi.response.SimpleIdResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,6 +28,7 @@ public class CodeReviewRestController {
 
     private final CodeReviewQueryService codeReviewQueryService;
     private final ReviewCommentQueryService reviewCommentQueryService;
+    private final CodeReviewService codeReviewService;
 
     @GetMapping
     public NoOffSetPagination<BasicCodeReview, Long> reviewList(@ModelAttribute CodeReviewListCondition condition) {
@@ -46,5 +51,11 @@ public class CodeReviewRestController {
     public ReviewCommentListResponse commentsOnReview(@Principal AuthInfo authInfo, @PathVariable Long reviewId) {
         final List<CommentReviewDetailDto> comments = reviewCommentQueryService.getCommentsOnReview(authInfo.getUserId(), reviewId);
         return new ReviewCommentListResponse(comments);
+    }
+
+    @PostMapping
+    public SimpleIdResponse createReview(@Principal AuthInfo authInfo, @Valid @RequestBody CreateCodeReviewRequest request) {
+        final Long codeReviewId = codeReviewService.create(authInfo.getUserId(), request.title(), request.content(), request.skillIds());
+        return new SimpleIdResponse(codeReviewId);
     }
 }

--- a/app-koi-api/src/main/java/com/codekoi/apiserver/review/controller/request/CreateCodeReviewRequest.java
+++ b/app-koi-api/src/main/java/com/codekoi/apiserver/review/controller/request/CreateCodeReviewRequest.java
@@ -1,0 +1,21 @@
+package com.codekoi.apiserver.review.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+
+public record CreateCodeReviewRequest(
+        @NotBlank String title,
+        @NotBlank String content,
+        List<Long> skillIds
+) {
+
+    public CreateCodeReviewRequest(String title, String content, List<Long> skillIds) {
+        this.title = title;
+        this.content = content;
+        this.skillIds = Objects.requireNonNullElse(skillIds, new ArrayList<>());
+    }
+}

--- a/app-koi-api/src/main/java/com/codekoi/apiserver/review/controller/request/UpdateCodeReveiwRequest.java
+++ b/app-koi-api/src/main/java/com/codekoi/apiserver/review/controller/request/UpdateCodeReveiwRequest.java
@@ -1,0 +1,19 @@
+package com.codekoi.apiserver.review.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public record UpdateCodeReveiwRequest(
+        @NotBlank String title,
+        @NotBlank String content,
+        List<Long> skillIds
+) {
+    public UpdateCodeReveiwRequest(String title, String content, List<Long> skillIds) {
+        this.title = title;
+        this.content = content;
+        this.skillIds = Objects.requireNonNullElse(skillIds, new ArrayList<>());
+    }
+}

--- a/app-koi-api/src/main/java/com/codekoi/apiserver/review/service/CodeReviewService.java
+++ b/app-koi-api/src/main/java/com/codekoi/apiserver/review/service/CodeReviewService.java
@@ -1,0 +1,20 @@
+package com.codekoi.apiserver.review.service;
+
+import com.codekoi.domain.review.usecase.CreateCodeReviewUsecase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CodeReviewService {
+
+    private final CreateCodeReviewUsecase createCodeReviewUsecase;
+
+    public Long create(Long userId, String title, String content, List<Long> skillIds) {
+        return createCodeReviewUsecase.command(new CreateCodeReviewUsecase.Command(userId, title, content, skillIds));
+    }
+}

--- a/app-koi-api/src/main/java/com/codekoi/apiserver/review/service/CodeReviewService.java
+++ b/app-koi-api/src/main/java/com/codekoi/apiserver/review/service/CodeReviewService.java
@@ -1,6 +1,7 @@
 package com.codekoi.apiserver.review.service;
 
 import com.codekoi.domain.review.usecase.CreateCodeReviewUsecase;
+import com.codekoi.domain.review.usecase.DeleteCodeReviewUsecase;
 import com.codekoi.domain.review.usecase.UpdateCodeReviewUsecase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ public class CodeReviewService {
 
     private final CreateCodeReviewUsecase createCodeReviewUsecase;
     private final UpdateCodeReviewUsecase updateCodeReviewUsecase;
+    private final DeleteCodeReviewUsecase deleteCodeReviewUsecase;
 
     public Long create(Long userId, String title, String content, List<Long> skillIds) {
         return createCodeReviewUsecase.command(new CreateCodeReviewUsecase.Command(userId, title, content, skillIds));
@@ -22,5 +24,9 @@ public class CodeReviewService {
 
     public void update(Long codeReviewId, Long userId, String title, String content, List<Long> skillIds) {
         updateCodeReviewUsecase.command(new UpdateCodeReviewUsecase.Command(codeReviewId, userId, title, content, skillIds));
+    }
+
+    public void delete(Long codeReviewId, Long userId) {
+        deleteCodeReviewUsecase.command(new DeleteCodeReviewUsecase.Command(codeReviewId, userId));
     }
 }

--- a/app-koi-api/src/main/java/com/codekoi/apiserver/review/service/CodeReviewService.java
+++ b/app-koi-api/src/main/java/com/codekoi/apiserver/review/service/CodeReviewService.java
@@ -1,6 +1,7 @@
 package com.codekoi.apiserver.review.service;
 
 import com.codekoi.domain.review.usecase.CreateCodeReviewUsecase;
+import com.codekoi.domain.review.usecase.UpdateCodeReviewUsecase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,8 +14,13 @@ import java.util.List;
 public class CodeReviewService {
 
     private final CreateCodeReviewUsecase createCodeReviewUsecase;
+    private final UpdateCodeReviewUsecase updateCodeReviewUsecase;
 
     public Long create(Long userId, String title, String content, List<Long> skillIds) {
         return createCodeReviewUsecase.command(new CreateCodeReviewUsecase.Command(userId, title, content, skillIds));
+    }
+
+    public void update(Long codeReviewId, Long userId, String title, String content, List<Long> skillIds) {
+        updateCodeReviewUsecase.command(new UpdateCodeReviewUsecase.Command(codeReviewId, userId, title, content, skillIds));
     }
 }

--- a/app-koi-api/src/test/java/com/codekoi/apiserver/review/controller/CodeReviewRestControllerTest.java
+++ b/app-koi-api/src/test/java/com/codekoi/apiserver/review/controller/CodeReviewRestControllerTest.java
@@ -2,6 +2,7 @@ package com.codekoi.apiserver.review.controller;
 
 import com.codekoi.apiserver.comment.dto.CommentReviewDetailDto;
 import com.codekoi.apiserver.docs.RestDocsCommonDescriptor;
+import com.codekoi.apiserver.review.controller.request.CreateCodeReviewRequest;
 import com.codekoi.apiserver.review.dto.BasicCodeReview;
 import com.codekoi.apiserver.review.dto.CodeReviewDetailDto;
 import com.codekoi.apiserver.utils.ControllerTest;
@@ -16,12 +17,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.codekoi.apiserver.utils.fixture.UserProfileDtoFixture.PROFILE1;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -50,16 +53,17 @@ class CodeReviewRestControllerTest extends ControllerTest {
         result
                 .andExpect(status().isOk())
                 .andDo(document("codeReviews/get",
-                        queryParameters(
-                                parameterWithName("status")
-                                        .description("코드리뷰 상태, PENDING, RESOLVED. 조건없으면 안보내기").optional(),
-                                parameterWithName("skillIds")
-                                        .description("기술 태그").optional(),
-                                parameterWithName("lastId")
-                                        .description("현재 페이지의 마지막 reviewId. 처음에는 없고 서버가 주는 값 그대로 전달").optional(),
-                                parameterWithName("title")
-                                        .description("제목 키워드").optional()
-                        ),
+                                queryParameters(
+                                        parameterWithName("status")
+                                                .description("코드리뷰 상태, PENDING, RESOLVED. 조건없으면 안보내기").optional(),
+                                        parameterWithName("skillIds")
+                                                .description("기술 태그").optional(),
+                                        parameterWithName("lastId")
+                                                .description("현재 페이지의 마지막 reviewId. 처음에는 없고 서버가 주는 값 그대로 전달").optional(),
+                                        parameterWithName("title")
+                                                .description("제목 키워드").optional()
+                                ),
+
                                 responseFields(
                                         fieldWithPath("list").type(JsonFieldType.ARRAY)
                                                 .description("코드리뷰 목록"),
@@ -207,5 +211,43 @@ class CodeReviewRestControllerTest extends ControllerTest {
                                         .description("스킬 목록")
                         ).and(RestDocsCommonDescriptor.userProfileDto("reviews[]"))
                 ));
+    }
+
+    @Test
+    void 코드리뷰_생성() throws Exception {
+        //given
+        final List<Long> SKILL_IDS = List.of(1L);
+        final CreateCodeReviewRequest request = new CreateCodeReviewRequest("제목", "내용", SKILL_IDS);
+
+        final long CREATED_CODE_REVIEW_ID = 2L;
+        given(codeReviewService.create(anyLong(), anyString(), anyString(), anyList()))
+                .willReturn(CREATED_CODE_REVIEW_ID);
+
+        //when
+        final ResultActions result = mvc.perform(
+                post("/api/code-reviews")
+                        .header(AUTHORIZATION, accessToken)
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request))
+        );
+
+        //then
+        result
+                .andExpect(status().isOk())
+                .andDo(document("codeReviews/post",
+                                requestFields(
+                                        fieldWithPath("title").type(JsonFieldType.STRING)
+                                                .description("코드리뷰 제목"),
+                                        fieldWithPath("content").type(JsonFieldType.STRING)
+                                                .description("코드리뷰 내용"),
+                                        fieldWithPath("skillIds").type(JsonFieldType.ARRAY)
+                                                .description("스킬 아이디 목록")
+                                ),
+                                responseFields(
+                                        fieldWithPath("id").type(JsonFieldType.NUMBER)
+                                                .description("생성된 코드리뷰 아이디")
+                                )
+                        )
+                );
     }
 }

--- a/app-koi-api/src/test/java/com/codekoi/apiserver/review/controller/CodeReviewRestControllerTest.java
+++ b/app-koi-api/src/test/java/com/codekoi/apiserver/review/controller/CodeReviewRestControllerTest.java
@@ -20,7 +20,6 @@ import java.util.List;
 import static com.codekoi.apiserver.utils.fixture.UserProfileDtoFixture.PROFILE1;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -269,8 +268,6 @@ class CodeReviewRestControllerTest extends ControllerTest {
         );
 
         //then
-        verify(codeReviewService).update(anyLong(), anyLong(), anyString(), anyString(), anyList());
-
         result
                 .andExpect(status().isOk())
                 .andDo(document("codeReviews/put-reviewId",
@@ -285,6 +282,29 @@ class CodeReviewRestControllerTest extends ControllerTest {
                                                 .description("코드리뷰 내용"),
                                         fieldWithPath("skillIds").type(JsonFieldType.ARRAY)
                                                 .description("스킬 아이디 목록")
+                                )
+                        )
+                );
+    }
+
+    @Test
+    void 코드리뷰_삭제() throws Exception {
+        //given
+
+        //when
+        final ResultActions result = mvc.perform(
+                delete("/api/code-reviews/{reviewId}", 1L)
+                        .header(AUTHORIZATION, accessToken)
+                        .contentType(APPLICATION_JSON)
+        );
+
+        //then
+        result
+                .andExpect(status().isOk())
+                .andDo(document("codeReviews/delete-reviewId",
+                                pathParameters(
+                                        parameterWithName("reviewId")
+                                                .description("코드리뷰 고유아이디")
                                 )
                         )
                 );

--- a/app-koi-api/src/test/java/com/codekoi/apiserver/review/controller/CodeReviewRestControllerTest.java
+++ b/app-koi-api/src/test/java/com/codekoi/apiserver/review/controller/CodeReviewRestControllerTest.java
@@ -3,6 +3,7 @@ package com.codekoi.apiserver.review.controller;
 import com.codekoi.apiserver.comment.dto.CommentReviewDetailDto;
 import com.codekoi.apiserver.docs.RestDocsCommonDescriptor;
 import com.codekoi.apiserver.review.controller.request.CreateCodeReviewRequest;
+import com.codekoi.apiserver.review.controller.request.UpdateCodeReveiwRequest;
 import com.codekoi.apiserver.review.dto.BasicCodeReview;
 import com.codekoi.apiserver.review.dto.CodeReviewDetailDto;
 import com.codekoi.apiserver.utils.ControllerTest;
@@ -19,11 +20,11 @@ import java.util.List;
 import static com.codekoi.apiserver.utils.fixture.UserProfileDtoFixture.PROFILE1;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -246,6 +247,44 @@ class CodeReviewRestControllerTest extends ControllerTest {
                                 responseFields(
                                         fieldWithPath("id").type(JsonFieldType.NUMBER)
                                                 .description("생성된 코드리뷰 아이디")
+                                )
+                        )
+                );
+    }
+
+    @Test
+    void 코드리뷰_수정() throws Exception {
+        //given
+        final String UPDATE_TITLE = "변경할 제목";
+        final String UPDATE_CONTENT = "변경할 내용";
+        final List<Long> UPDATE_SKILL_IDS = List.of(1L, 2L);
+        UpdateCodeReveiwRequest request = new UpdateCodeReveiwRequest(UPDATE_TITLE, UPDATE_CONTENT, UPDATE_SKILL_IDS);
+
+        //when
+        final ResultActions result = mvc.perform(
+                put("/api/code-reviews/{reviewId}", 1L)
+                        .header(AUTHORIZATION, accessToken)
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request))
+        );
+
+        //then
+        verify(codeReviewService).update(anyLong(), anyLong(), anyString(), anyString(), anyList());
+
+        result
+                .andExpect(status().isOk())
+                .andDo(document("codeReviews/put-reviewId",
+                                pathParameters(
+                                        parameterWithName("reviewId")
+                                                .description("코드리뷰 고유아이디")
+                                ),
+                                requestFields(
+                                        fieldWithPath("title").type(JsonFieldType.STRING)
+                                                .description("코드리뷰 제목"),
+                                        fieldWithPath("content").type(JsonFieldType.STRING)
+                                                .description("코드리뷰 내용"),
+                                        fieldWithPath("skillIds").type(JsonFieldType.ARRAY)
+                                                .description("스킬 아이디 목록")
                                 )
                         )
                 );

--- a/app-koi-api/src/test/java/com/codekoi/apiserver/utils/ControllerTest.java
+++ b/app-koi-api/src/test/java/com/codekoi/apiserver/utils/ControllerTest.java
@@ -7,6 +7,7 @@ import com.codekoi.apiserver.like.controller.LikeRestController;
 import com.codekoi.apiserver.like.service.LikeService;
 import com.codekoi.apiserver.review.controller.CodeReviewRestController;
 import com.codekoi.apiserver.review.service.CodeReviewQueryService;
+import com.codekoi.apiserver.review.service.CodeReviewService;
 import com.codekoi.apiserver.skill.review.service.CodeReviewSkillQueryService;
 import com.codekoi.apiserver.skill.skill.controller.SkillRestController;
 import com.codekoi.apiserver.skill.skill.service.SkillQueryService;
@@ -79,4 +80,6 @@ public abstract class ControllerTest {
     protected SkillQueryService skillQueryService;
     @MockBean
     protected CodeReviewSkillQueryService codeReviewSkillQueryService;
+    @MockBean
+    protected CodeReviewService codeReviewService;
 }

--- a/app-koi-api/src/test/java/com/codekoi/apiserver/utils/ControllerTest.java
+++ b/app-koi-api/src/test/java/com/codekoi/apiserver/utils/ControllerTest.java
@@ -3,6 +3,7 @@ package com.codekoi.apiserver.utils;
 import com.codekoi.apiserver.auth.service.AuthService;
 import com.codekoi.apiserver.comment.controller.CommentRestController;
 import com.codekoi.apiserver.comment.service.ReviewCommentQueryService;
+import com.codekoi.apiserver.comment.service.ReviewCommentService;
 import com.codekoi.apiserver.like.controller.LikeRestController;
 import com.codekoi.apiserver.like.service.LikeService;
 import com.codekoi.apiserver.review.controller.CodeReviewRestController;
@@ -82,4 +83,6 @@ public abstract class ControllerTest {
     protected CodeReviewSkillQueryService codeReviewSkillQueryService;
     @MockBean
     protected CodeReviewService codeReviewService;
+    @MockBean
+    protected ReviewCommentService reviewCommentService;
 }

--- a/domain/src/main/java/com/codekoi/domain/review/CodeReview.java
+++ b/domain/src/main/java/com/codekoi/domain/review/CodeReview.java
@@ -49,7 +49,7 @@ public class CodeReview extends TimeBaseEntity {
         this.content = content;
         this.status = status;
         this.skills = Objects.requireNonNullElse(skills, new ArrayList<>());
-        this.comments = Objects.requireNonNullElse(comments, new ArrayList<>());;
+        this.comments = Objects.requireNonNullElse(comments, new ArrayList<>());
     }
 
     public static CodeReview of(User user, String title, String content) {
@@ -75,6 +75,18 @@ public class CodeReview extends TimeBaseEntity {
                 .map(CodeReviewSkill::getSkill)
                 .map(Skill::getName)
                 .collect(Collectors.toList());
+    }
+
+    public boolean isMyCodeReview(Long userId) {
+        return user.getId().equals(userId);
+    }
+
+    public void update(String title, String content, List<Skill> skills) {
+        this.title = title;
+        this.content = content;
+
+        this.skills.clear();
+        skills.forEach(this::addCodeReviewSkill);
     }
 
     public Long getId() {

--- a/domain/src/main/java/com/codekoi/domain/review/service/CreateCodeReview.java
+++ b/domain/src/main/java/com/codekoi/domain/review/service/CreateCodeReview.java
@@ -1,0 +1,37 @@
+package com.codekoi.domain.review.service;
+
+import com.codekoi.domain.review.CodeReview;
+import com.codekoi.domain.review.CodeReviewRepository;
+import com.codekoi.domain.review.usecase.CreateCodeReviewUsecase;
+import com.codekoi.domain.skill.skill.Skill;
+import com.codekoi.domain.skill.skill.SkillRepository;
+import com.codekoi.domain.user.User;
+import com.codekoi.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CreateCodeReview implements CreateCodeReviewUsecase {
+
+    private final UserRepository userRepository;
+    private final CodeReviewRepository codeReviewRepository;
+    private final SkillRepository skillRepository;
+
+    @Override
+    public Long command(Command command) {
+        final User user = userRepository.getOneById(command.userId());
+
+        final CodeReview codeReview = CodeReview.of(user, command.title(), command.content());
+        codeReviewRepository.save(codeReview);
+
+        List<Skill> skills = skillRepository.findAllById(command.skillIds());
+        skills.forEach(codeReview::addCodeReviewSkill);
+
+        return codeReview.getId();
+    }
+}

--- a/domain/src/main/java/com/codekoi/domain/review/service/DeleteCodeReview.java
+++ b/domain/src/main/java/com/codekoi/domain/review/service/DeleteCodeReview.java
@@ -1,0 +1,27 @@
+package com.codekoi.domain.review.service;
+
+import com.codekoi.domain.review.CodeReview;
+import com.codekoi.domain.review.CodeReviewRepository;
+import com.codekoi.domain.review.usecase.DeleteCodeReviewUsecase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DeleteCodeReview implements DeleteCodeReviewUsecase {
+
+    private final CodeReviewRepository codeReviewRepository;
+
+    @Override
+    public void command(Command command) {
+        CodeReview codeReview = codeReviewRepository.getOneById(command.codeReviewId());
+
+        if (!codeReview.isMyCodeReview(command.userId())) {
+            return;
+        }
+
+        codeReviewRepository.delete(codeReview);
+    }
+}

--- a/domain/src/main/java/com/codekoi/domain/review/service/UpdateCodeReview.java
+++ b/domain/src/main/java/com/codekoi/domain/review/service/UpdateCodeReview.java
@@ -1,0 +1,33 @@
+package com.codekoi.domain.review.service;
+
+import com.codekoi.domain.review.CodeReview;
+import com.codekoi.domain.review.CodeReviewRepository;
+import com.codekoi.domain.review.usecase.UpdateCodeReviewUsecase;
+import com.codekoi.domain.skill.skill.Skill;
+import com.codekoi.domain.skill.skill.SkillRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UpdateCodeReview implements UpdateCodeReviewUsecase {
+
+    private final CodeReviewRepository codeReviewRepository;
+    private final SkillRepository skillRepository;
+
+    @Override
+    public void command(Command command) {
+        CodeReview codeReview = codeReviewRepository.getOneById(command.codeReviewId());
+
+        if (!codeReview.isMyCodeReview(command.userId())) {
+            return;
+        }
+        List<Skill> skills = skillRepository.findAllById(command.skillIds());
+
+        codeReview.update(command.title(), command.content(), skills);
+    }
+}

--- a/domain/src/main/java/com/codekoi/domain/review/usecase/CreateCodeReviewUsecase.java
+++ b/domain/src/main/java/com/codekoi/domain/review/usecase/CreateCodeReviewUsecase.java
@@ -1,0 +1,17 @@
+package com.codekoi.domain.review.usecase;
+
+import java.util.List;
+
+public interface CreateCodeReviewUsecase {
+
+    Long command(Command command);
+
+    record Command(
+            Long userId,
+            String title,
+            String content,
+            List<Long> skillIds
+    ) {
+
+    }
+}

--- a/domain/src/main/java/com/codekoi/domain/review/usecase/DeleteCodeReviewUsecase.java
+++ b/domain/src/main/java/com/codekoi/domain/review/usecase/DeleteCodeReviewUsecase.java
@@ -1,0 +1,12 @@
+package com.codekoi.domain.review.usecase;
+
+public interface DeleteCodeReviewUsecase {
+
+    void command(Command command);
+
+    record Command(
+            Long codeReviewId,
+            Long userId
+    ) {
+    }
+}

--- a/domain/src/main/java/com/codekoi/domain/review/usecase/UpdateCodeReviewUsecase.java
+++ b/domain/src/main/java/com/codekoi/domain/review/usecase/UpdateCodeReviewUsecase.java
@@ -1,0 +1,17 @@
+package com.codekoi.domain.review.usecase;
+
+import java.util.List;
+
+public interface UpdateCodeReviewUsecase {
+
+    void command(Command command);
+
+    record Command(
+            Long codeReviewId,
+            Long userId,
+            String title,
+            String content,
+            List<Long> skillIds
+    ) {
+    }
+}

--- a/domain/src/test/java/com/codekoi/domain/review/service/CreateCodeReviewTest.java
+++ b/domain/src/test/java/com/codekoi/domain/review/service/CreateCodeReviewTest.java
@@ -1,0 +1,84 @@
+package com.codekoi.domain.review.service;
+
+import com.codekoi.domain.review.CodeReview;
+import com.codekoi.domain.review.CodeReviewRepository;
+import com.codekoi.domain.review.usecase.CreateCodeReviewUsecase;
+import com.codekoi.domain.skill.skill.Skill;
+import com.codekoi.domain.skill.skill.SkillRepository;
+import com.codekoi.domain.user.User;
+import com.codekoi.domain.user.UserRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static com.codekoi.fixture.CodeReviewFixture.REVIEW1;
+import static com.codekoi.fixture.SkillFixture.JAVA;
+import static com.codekoi.fixture.SkillFixture.JPA;
+import static com.codekoi.fixture.UserFixture.SUNDO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CreateCodeReviewTest {
+
+    @InjectMocks
+    private CreateCodeReview createCodeReview;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CodeReviewRepository codeReviewRepository;
+
+    @Mock
+    private SkillRepository skillRepository;
+
+    @Captor
+    ArgumentCaptor<CodeReview> codeReviewCaptor;
+
+    @Test
+    void 코드리뷰를_생성한다() {
+        //given
+        final long USER_ID = 1L;
+        User user = SUNDO.toUser(USER_ID);
+
+        final long JPA_ID = 2L;
+        final long JAVA_ID = 3L;
+        final List<Long> SKILL_IDS = List.of(JPA_ID, JAVA_ID);
+        List<Skill> skills = List.of(JPA.toSkill(JPA_ID), JAVA.toSkill(JAVA_ID));
+
+        given(userRepository.getOneById(anyLong())).willReturn(user);
+        given(skillRepository.findAllById(anyList())).willReturn(skills);
+
+        //when
+        final String REVIEW_TITLE = REVIEW1.title;
+        final String REVIEW_CONTENT = REVIEW1.content;
+        createCodeReview.command(new CreateCodeReviewUsecase.Command(USER_ID, REVIEW_TITLE, REVIEW_CONTENT, SKILL_IDS));
+
+        //then
+        verify(codeReviewRepository).save(codeReviewCaptor.capture());
+        final CodeReview codeReview = codeReviewCaptor.getValue();
+
+        assertThat(codeReview.getUser().getId()).isEqualTo(USER_ID);
+
+        assertThat(codeReview.getTitle()).isEqualTo(REVIEW_TITLE);
+        assertThat(codeReview.getContent()).isEqualTo(REVIEW_CONTENT);
+
+        assertThat(codeReview.getSkills()).hasSize(2);
+        assertThat(codeReview.getSkills()).extracting("skill").extracting("id")
+                .containsExactlyInAnyOrder(JPA_ID, JAVA_ID);
+    }
+}

--- a/domain/src/test/java/com/codekoi/domain/review/service/DeleteCodeReviewTest.java
+++ b/domain/src/test/java/com/codekoi/domain/review/service/DeleteCodeReviewTest.java
@@ -1,0 +1,63 @@
+package com.codekoi.domain.review.service;
+
+import com.codekoi.domain.review.CodeReview;
+import com.codekoi.domain.review.CodeReviewRepository;
+import com.codekoi.domain.review.usecase.DeleteCodeReviewUsecase;
+import com.codekoi.domain.user.User;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.codekoi.fixture.CodeReviewFixture.REVIEW1;
+import static com.codekoi.fixture.UserFixture.SUNDO;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DeleteCodeReviewTest {
+
+    @InjectMocks
+    private DeleteCodeReview deleteCodeReview;
+
+    @Mock
+    private CodeReviewRepository codeReviewRepository;
+
+    @Test
+    void 코드리뷰_삭제() {
+        //given
+        final long CODE_REVIEW_ID = 1L;
+        final long USER_ID = 2L;
+        final User user = SUNDO.toUser(USER_ID);
+        final CodeReview codeReview = REVIEW1.toCodeReview(CODE_REVIEW_ID, user);
+
+        given(codeReviewRepository.getOneById(anyLong())).willReturn(codeReview);
+
+        //when
+        deleteCodeReview.command(new DeleteCodeReviewUsecase.Command(CODE_REVIEW_ID, USER_ID));
+
+        //then
+        verify(codeReviewRepository).delete(any(CodeReview.class));
+    }
+
+    @Test
+    void 내가_작성한_코드리뷰가_아니면_코드리뷰_삭제에_실패한다() {
+        //given
+        final long CODE_REVIEW_ID = 1L;
+        final long USER_ID = 2L;
+        final User user = SUNDO.toUser(USER_ID);
+        final CodeReview codeReview = REVIEW1.toCodeReview(CODE_REVIEW_ID, user);
+
+        given(codeReviewRepository.getOneById(anyLong())).willReturn(codeReview);
+
+        //when
+        final long ANOTHER_USER_ID = 3L;
+        deleteCodeReview.command(new DeleteCodeReviewUsecase.Command(CODE_REVIEW_ID, ANOTHER_USER_ID));
+
+        //then
+        verify(codeReviewRepository, never()).delete(any(CodeReview.class));
+    }
+}

--- a/domain/src/test/java/com/codekoi/domain/review/service/UpdateCodeReviewTest.java
+++ b/domain/src/test/java/com/codekoi/domain/review/service/UpdateCodeReviewTest.java
@@ -1,0 +1,90 @@
+package com.codekoi.domain.review.service;
+
+import com.codekoi.domain.review.CodeReview;
+import com.codekoi.domain.review.CodeReviewRepository;
+import com.codekoi.domain.review.usecase.UpdateCodeReviewUsecase;
+import com.codekoi.domain.skill.skill.Skill;
+import com.codekoi.domain.skill.skill.SkillRepository;
+import com.codekoi.domain.user.User;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static com.codekoi.fixture.CodeReviewFixture.REVIEW1;
+import static com.codekoi.fixture.CodeReviewFixture.REVIEW2;
+import static com.codekoi.fixture.SkillFixture.JPA;
+import static com.codekoi.fixture.UserFixture.SUNDO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UpdateCodeReviewTest {
+
+    @InjectMocks
+    private UpdateCodeReview updateCodeReview;
+
+    @Mock
+    private CodeReviewRepository codeReviewRepository;
+
+    @Mock
+    private SkillRepository skillRepository;
+
+
+    @Test
+    void 코드리뷰를_변경한다() {
+        //given
+        final Long CODE_REVIEW_ID = 1L;
+        final Long USER_ID = 2L;
+        final User user = SUNDO.toUser(USER_ID);
+        final CodeReview codeReview = REVIEW1.toCodeReview(CODE_REVIEW_ID, user);
+
+        final Long SKILL_ID = 3L;
+        final Skill skill = JPA.toSkill(SKILL_ID);
+
+        given(codeReviewRepository.getOneById(anyLong())).willReturn(codeReview);
+        given(skillRepository.findAllById(anyList())).willReturn(List.of(skill));
+
+        //when
+        final String UPDATE_TITLE = REVIEW2.title;
+        final String UPDATE_CONTENT = REVIEW2.content;
+        final List<Long> UPDATE_SKILL_IDS = List.of(SKILL_ID);
+        updateCodeReview.command(new UpdateCodeReviewUsecase.Command(CODE_REVIEW_ID, USER_ID, UPDATE_TITLE, UPDATE_CONTENT, UPDATE_SKILL_IDS));
+
+        //then
+        assertThat(codeReview.getTitle()).isEqualTo(UPDATE_TITLE);
+        assertThat(codeReview.getContent()).isEqualTo(UPDATE_CONTENT);
+
+        assertThat(codeReview.getSkills()).hasSize(1);
+        assertThat(codeReview.getSkills()).extracting("skill").extracting("id")
+                .containsExactlyInAnyOrder(SKILL_ID);
+    }
+
+    @Test
+    void 내가_작성한_코드리뷰가_아니면_코드리뷰_변경에_실패한다() {
+        //given
+        final Long CODE_REVIEW_ID = 1L;
+        final Long USER_ID = 2L;
+        User user = SUNDO.toUser(USER_ID);
+        final CodeReview codeReview = REVIEW1.toCodeReview(CODE_REVIEW_ID, user);
+
+        given(codeReviewRepository.getOneById(anyLong())).willReturn(codeReview);
+
+        //when
+        final Long ANOTHER_USER_ID = 3L;
+        updateCodeReview.command(new UpdateCodeReviewUsecase.Command(CODE_REVIEW_ID, ANOTHER_USER_ID, "", "", List.of()));
+
+        //then
+        verify(skillRepository, never()).findAllById(anyList());
+    }
+}


### PR DESCRIPTION
코드리뷰 생성, 수정, 삭제 기능 구현했습니다.
기존 ControllerTest에서 ReviewCommentService 의존성 누락으로 테스트 실패하는 문제 해결했습니다.
구현 기능들 Rest Docs에 추가했습니다.